### PR TITLE
Use env vars for DB and doc setup

### DIFF
--- a/Readme
+++ b/Readme
@@ -954,5 +954,20 @@
        'task'    : 'cashflow.tasks.check_lcrequests_expiry',
        'schedule': crontab(hour=1, minute=0),
      },
-   }
+  }
+
+## Environment Variables
+
+The application relies on several environment variables which can be defined in
+a `.env` file or exported in the shell. At a minimum the following variables are
+required:
+
+- `SECRET_KEY` – Django secret key value.
+- `DEBUG` – set to `1` to enable debug mode.
+- `ALLOWED_HOSTS` – comma separated list of allowed hostnames.
+- `DB_NAME` – PostgreSQL database name.
+- `DB_USER` – database username.
+- `DB_PASSWORD` – database password.
+- `DB_HOST` – database host address.
+- `DB_PORT` – database port number.
 

--- a/cashcrm_project/settings.py
+++ b/cashcrm_project/settings.py
@@ -29,7 +29,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DEBUG')
+DEBUG = os.getenv('DEBUG', '0') == '1'
 
 ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')
 
@@ -131,11 +131,11 @@ CHANNEL_LAYERS = {
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'cashcrmDB',
-        'USER': 'mareng2007',
-        'PASSWORD': 'Skr4018kku',
-        'HOST': 'localhost',  # หรือเป็น IP หรือชื่อโฮสต์ของฐานข้อมูล
-        'PORT': '5432',  # Default PostgreSQL port
+        'NAME': os.getenv('DB_NAME'),
+        'USER': os.getenv('DB_USER'),
+        'PASSWORD': os.getenv('DB_PASSWORD'),
+        'HOST': os.getenv('DB_HOST'),  # หรือเป็น IP หรือชื่อโฮสต์ของฐานข้อมูล
+        'PORT': os.getenv('DB_PORT'),  # Default PostgreSQL port
     }
 }
 


### PR DESCRIPTION
## Summary
- load DEBUG as a bool via env var
- use environment variables for database connection
- document required environment variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684040c86a1c832db22d694538a0d8be