### PR TITLE
Link AccountsReceivable to BankAccount

### DIFF
--- a/revenue/forms.py
+++ b/revenue/forms.py
@@ -25,7 +25,7 @@ class AccountsReceivableForm(forms.ModelForm):
         fields = [
             'revenue_job', 'invoice_number',
             'invoice_date', 'due_date',
-            'total_amount', 'paid_amount', 'status'
+            'total_amount', 'paid_amount', 'bank_account', 'status'
         ]
         widgets = {
             'revenue_job': forms.Select(attrs={'class': 'form-select'}),
@@ -34,5 +34,6 @@ class AccountsReceivableForm(forms.ModelForm):
             'due_date': forms.DateInput(attrs={'type': 'date', 'class': 'form-control'}),
             'total_amount': forms.NumberInput(attrs={'class': 'form-control'}),
             'paid_amount': forms.NumberInput(attrs={'class': 'form-control'}),
+            'bank_account': forms.Select(attrs={'class': 'form-select'}),
             'status': forms.Select(attrs={'class': 'form-select'}),
         }

--- a/revenue/models.py
+++ b/revenue/models.py
@@ -59,6 +59,12 @@ class AccountsReceivable(models.Model):
     due_date = models.DateField()
     total_amount = models.DecimalField(max_digits=14, decimal_places=2)
     paid_amount = models.DecimalField(max_digits=14, decimal_places=2, default=Decimal('0.00'))
+    bank_account = models.ForeignKey(
+        'cashflow.BankAccount',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True
+    )
     status = models.CharField(
         max_length=20,
         choices=[

--- a/revenue/serializers.py
+++ b/revenue/serializers.py
@@ -19,7 +19,7 @@ class AccountsReceivableSerializer(serializers.ModelSerializer):
         model = AccountsReceivable
         fields = [
             'id', 'revenue_job', 'invoice_number', 'invoice_date',
-            'due_date', 'total_amount', 'paid_amount', 'status'
+            'due_date', 'total_amount', 'paid_amount', 'bank_account', 'status'
         ]
 
     def create(self, validated_data):

--- a/revenue/templates/revenue/accountsreceivable_detail.html
+++ b/revenue/templates/revenue/accountsreceivable_detail.html
@@ -30,6 +30,13 @@
         <dt class="col-sm-3">Paid Amount</dt>
         <dd class="col-sm-9">{{ ar.paid_amount|floatformat:2 }}</dd>
 
+        <dt class="col-sm-3">Bank Account</dt>
+        <dd class="col-sm-9">
+          {% if ar.bank_account %}
+            {{ ar.bank_account }}
+          {% else %}-{% endif %}
+        </dd>
+
         <dt class="col-sm-3">Status</dt>
         <dd class="col-sm-9">
           {% if ar.status == 'Unpaid' %}

--- a/revenue/templates/revenue/accountsreceivable_form.html
+++ b/revenue/templates/revenue/accountsreceivable_form.html
@@ -70,6 +70,12 @@
           </div>
         </div>
 
+        <div class="mb-3">
+          {{ form.bank_account.label_tag }}
+          {{ form.bank_account }}
+          {{ form.bank_account.errors }}
+        </div>
+
         <button type="submit" class="btn btn-success">
           {% if object %}บันทึก{% else %}สร้างใหม่{% endif %}
         </button>


### PR DESCRIPTION
## Summary
- connect AccountsReceivable with BankAccount
- expose the new field in forms and serializer
- record selected bank account when updating AccountsReceivable
- show bank account in AR templates

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684040f910a4832d88f241c0ba0ef225