### PR TITLE
Add filtering and pagination for revenue lists

### DIFF
--- a/cashcrm_project/settings.py
+++ b/cashcrm_project/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     'django_celery_beat',
     'corsheaders',
+    'django_filters',
 
     # แอปภายในโปรเจกต์
     'core',     # core_02 (Dashboard, Permissions ใหม่)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ cron-descriptor==1.4.5
 Django==4.2.21
 django-celery-beat==2.8.1
 django-cors-headers==4.4.0
+django-filter==23.5
 django-smtp-ssl==1.0
 django-timezone-field==7.1
 djangorestframework==3.15.2

--- a/revenue/filters.py
+++ b/revenue/filters.py
@@ -1,0 +1,49 @@
+import django_filters
+from django import forms
+from django.db.models import Q
+from .models import RevenueJob, AccountsReceivable
+
+class RevenueJobFilter(django_filters.FilterSet):
+    q = django_filters.CharFilter(
+        method='filter_q',
+        label='ค้นหา',
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'ค้นหา...'}),
+    )
+    status = django_filters.ChoiceFilter(
+        choices=RevenueJob._meta.get_field('status').choices,
+        label='สถานะ',
+        empty_label='ทั้งหมด',
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+
+    class Meta:
+        model = RevenueJob
+        fields = ['q', 'status']
+
+    def filter_q(self, queryset, name, value):
+        return queryset.filter(Q(description__icontains=value) | Q(job_code__icontains=value))
+
+
+class AccountsReceivableFilter(django_filters.FilterSet):
+    q = django_filters.CharFilter(
+        method='filter_q',
+        label='ค้นหา',
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'ค้นหา...'}),
+    )
+    status = django_filters.ChoiceFilter(
+        choices=AccountsReceivable._meta.get_field('status').choices,
+        label='สถานะ',
+        empty_label='ทั้งหมด',
+        widget=forms.Select(attrs={'class': 'form-select'}),
+    )
+
+    class Meta:
+        model = AccountsReceivable
+        fields = ['q', 'status']
+
+    def filter_q(self, queryset, name, value):
+        return queryset.filter(
+            Q(invoice_number__icontains=value) |
+            Q(revenue_job__job_code__icontains=value) |
+            Q(revenue_job__description__icontains=value)
+        )

--- a/revenue/templates/revenue/accountsreceivable_list.html
+++ b/revenue/templates/revenue/accountsreceivable_list.html
@@ -12,6 +12,20 @@
     </a>
   </div>
 
+  <form method="get" class="row g-2 mb-3">
+    <div class="col-md-5">
+      {{ filter.form.q.label_tag }}
+      {{ filter.form.q }}
+    </div>
+    <div class="col-md-3">
+      {{ filter.form.status.label_tag }}
+      {{ filter.form.status }}
+    </div>
+    <div class="col-md-2 align-self-end">
+      <button type="submit" class="btn btn-outline-primary w-100">Filter</button>
+    </div>
+  </form>
+
   <table class="table table-hover">
     <thead class="table-light">
       <tr>
@@ -61,5 +75,28 @@
       {% endfor %}
     </tbody>
   </table>
+  {% if is_paginated %}
+    <nav aria-label="Page navigation">
+      <ul class="pagination">
+        {% if page_obj.has_previous %}
+          <li class="page-item"><a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&amp;{% endif %}{% if request.GET.status %}status={{ request.GET.status }}&amp;{% endif %}page={{ page_obj.previous_page_number }}">Previous</a></li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">Previous</span></li>
+        {% endif %}
+        {% for num in paginator.page_range %}
+          {% if num == page_obj.number %}
+            <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+          {% else %}
+            <li class="page-item"><a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&amp;{% endif %}{% if request.GET.status %}status={{ request.GET.status }}&amp;{% endif %}page={{ num }}">{{ num }}</a></li>
+          {% endif %}
+        {% endfor %}
+        {% if page_obj.has_next %}
+          <li class="page-item"><a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&amp;{% endif %}{% if request.GET.status %}status={{ request.GET.status }}&amp;{% endif %}page={{ page_obj.next_page_number }}">Next</a></li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">Next</span></li>
+        {% endif %}
+      </ul>
+    </nav>
+  {% endif %}
 </div>
 {% endblock %}

--- a/revenue/templates/revenue/revenuejob_list.html
+++ b/revenue/templates/revenue/revenuejob_list.html
@@ -12,6 +12,20 @@
     </a>
   </div>
 
+  <form method="get" class="row g-2 mb-3">
+    <div class="col-md-5">
+      {{ filter.form.q.label_tag }}
+      {{ filter.form.q }}
+    </div>
+    <div class="col-md-3">
+      {{ filter.form.status.label_tag }}
+      {{ filter.form.status }}
+    </div>
+    <div class="col-md-2 align-self-end">
+      <button type="submit" class="btn btn-outline-primary w-100">Filter</button>
+    </div>
+  </form>
+
   <table class="table table-hover">
     <thead class="table-light">
       <tr>
@@ -59,6 +73,29 @@
       {% endfor %}
     </tbody>
   </table>
+  {% if is_paginated %}
+    <nav aria-label="Page navigation">
+      <ul class="pagination">
+        {% if page_obj.has_previous %}
+          <li class="page-item"><a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&amp;{% endif %}{% if request.GET.status %}status={{ request.GET.status }}&amp;{% endif %}page={{ page_obj.previous_page_number }}">Previous</a></li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">Previous</span></li>
+        {% endif %}
+        {% for num in paginator.page_range %}
+          {% if num == page_obj.number %}
+            <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+          {% else %}
+            <li class="page-item"><a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&amp;{% endif %}{% if request.GET.status %}status={{ request.GET.status }}&amp;{% endif %}page={{ num }}">{{ num }}</a></li>
+          {% endif %}
+        {% endfor %}
+        {% if page_obj.has_next %}
+          <li class="page-item"><a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&amp;{% endif %}{% if request.GET.status %}status={{ request.GET.status }}&amp;{% endif %}page={{ page_obj.next_page_number }}">Next</a></li>
+        {% else %}
+          <li class="page-item disabled"><span class="page-link">Next</span></li>
+        {% endif %}
+      </ul>
+    </nav>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/revenue/views.py
+++ b/revenue/views.py
@@ -17,6 +17,7 @@ from core.mixins import RevenueAccessRequiredMixin
 
 from .models import RevenueJob, AccountsReceivable
 from .forms import RevenueJobForm, AccountsReceivableForm
+from .filters import RevenueJobFilter, AccountsReceivableFilter
 from .serializers import RevenueJobSerializer, AccountsReceivableSerializer
 
 
@@ -61,6 +62,17 @@ class RevenueJobListView(RevenueAccessRequiredMixin, ListView):
     model = RevenueJob
     template_name = 'revenue/revenuejob_list.html'
     context_object_name = 'jobs'
+    paginate_by = 10
+
+    def get_queryset(self):
+        qs = RevenueJob.objects.all().order_by('-date')
+        self.filterset = RevenueJobFilter(self.request.GET, queryset=qs)
+        return self.filterset.qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['filter'] = self.filterset
+        return context
 
 
 class RevenueJobCreateView(RevenueAccessRequiredMixin, CreateView):
@@ -104,6 +116,17 @@ class AccountsReceivableListView(RevenueAccessRequiredMixin, ListView):
     model = AccountsReceivable
     template_name = 'revenue/accountsreceivable_list.html'
     context_object_name = 'ars'
+    paginate_by = 10
+
+    def get_queryset(self):
+        qs = AccountsReceivable.objects.select_related('revenue_job').all().order_by('-invoice_date')
+        self.filterset = AccountsReceivableFilter(self.request.GET, queryset=qs)
+        return self.filterset.qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['filter'] = self.filterset
+        return context
 
 
 class AccountsReceivableCreateView(RevenueAccessRequiredMixin, CreateView):


### PR DESCRIPTION
## Summary
- integrate django-filter for RevenueJob and AccountsReceivable lists
- support query parameters for text search and status filter
- add pagination to revenue list views
- display filter form and pagination controls in templates
- include django-filter in requirements and settings

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68404112932c832d8186fd8791587ecc