### PR TITLE
Add registration and revenue CRUD tests

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,78 @@
-from django.test import TestCase
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.core import mail
 
-# Create your tests here.
+from core.models import EmailActivation, OTP, UserProfile
+
+
+@override_settings(
+    SECRET_KEY="testsecret",
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DATABASES={
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    },
+)
+class CoreFlowTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def _register_user(self):
+        url = reverse("core:register")
+        data = {
+            "username": "tester",
+            "email": "tester@example.com",
+            "password1": "StrongPass123",
+            "password2": "StrongPass123",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        user = User.objects.get(username="tester")
+        self.assertFalse(user.is_active)
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())
+        self.assertTrue(EmailActivation.objects.filter(user=user).exists())
+        self.assertEqual(len(mail.outbox), 1)
+        return user, EmailActivation.objects.get(user=user)
+
+    def test_registration_and_activation(self):
+        user, activation = self._register_user()
+
+        uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+        url = reverse("core:activate", kwargs={"uidb64": uidb64, "token": activation.token})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        user.refresh_from_db()
+        activation.refresh_from_db()
+        self.assertTrue(user.is_active)
+        self.assertTrue(activation.is_used)
+
+    def test_login_with_otp_flow(self):
+        user, activation = self._register_user()
+
+        uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+        self.client.get(reverse("core:activate", kwargs={"uidb64": uidb64, "token": activation.token}))
+
+        login_url = reverse("core:login")
+        response = self.client.post(login_url, {"username": "tester", "password": "StrongPass123"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("core:login_verify_otp"))
+
+        otp = OTP.objects.latest("created_at")
+        self.assertFalse(otp.is_used)
+        self.assertIn("pre_2fa_user_id", self.client.session)
+
+        verify_url = reverse("core:login_verify_otp")
+        response = self.client.post(verify_url, {"email": user.email, "code": otp.code})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("core:home"))
+
+        otp.refresh_from_db()
+        self.assertTrue(otp.is_used)
+        response = self.client.get(reverse("core:home"))
+        self.assertTrue(response.wsgi_request.user.is_authenticated)

--- a/revenue/tests.py
+++ b/revenue/tests.py
@@ -1,3 +1,91 @@
-from django.test import TestCase
+from django.test import TestCase, Client, override_settings
+from django.contrib.auth.models import User, Group
+from decimal import Decimal
 
-# Create your tests here.
+from revenue.models import RevenueJob, AccountsReceivable
+
+
+@override_settings(
+    SECRET_KEY="testsecret",
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DATABASES={
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    },
+)
+class RevenueCRUDTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.group = Group.objects.create(name="revenue_access")
+        self.user = User.objects.create_user("revuser", password="pass123", is_active=True)
+        self.user.groups.add(self.group)
+        self.client.login(username="revuser", password="pass123")
+
+    def test_revenuejob_crud(self):
+        create_data = {
+            "date": "2025-01-01",
+            "job_code": "Job1",
+            "description": "Test Job",
+            "volume": "10.00",
+            "income_amount": "1000.00",
+            "status": "Pending",
+        }
+        resp = self.client.post("/revenue/api/jobs/", create_data)
+        self.assertEqual(resp.status_code, 201)
+        job_id = resp.json()["id"]
+        self.assertEqual(RevenueJob.objects.count(), 1)
+
+        resp = self.client.get(f"/revenue/api/jobs/{job_id}/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["description"], "Test Job")
+
+        resp = self.client.patch(
+            f"/revenue/api/jobs/{job_id}/",
+            data={"status": "Invoiced"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(RevenueJob.objects.get(id=job_id).status, "Invoiced")
+
+        resp = self.client.delete(f"/revenue/api/jobs/{job_id}/")
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(RevenueJob.objects.count(), 0)
+
+    def test_accountsreceivable_crud(self):
+        job = RevenueJob.objects.create(
+            date="2025-01-01",
+            job_code="Job2",
+            description="AR Job",
+            volume=Decimal("5.00"),
+            income_amount=Decimal("500.00"),
+        )
+        ar_data = {
+            "revenue_job": job.id,
+            "invoice_number": "INV001",
+            "invoice_date": "2025-01-05",
+            "due_date": "2025-02-05",
+            "total_amount": "500.00",
+            "paid_amount": "0.00",
+            "status": "Unpaid",
+        }
+        resp = self.client.post("/revenue/api/ar/", ar_data)
+        self.assertEqual(resp.status_code, 201)
+        ar_id = resp.json()["id"]
+        self.assertEqual(AccountsReceivable.objects.count(), 1)
+        job.refresh_from_db()
+        self.assertEqual(job.status, "Invoiced")
+
+        resp = self.client.patch(
+            f"/revenue/api/ar/{ar_id}/",
+            data={"paid_amount": "500.00"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        ar = AccountsReceivable.objects.get(id=ar_id)
+        self.assertEqual(ar.status, "Paid")
+
+        resp = self.client.delete(f"/revenue/api/ar/{ar_id}/")
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(AccountsReceivable.objects.count(), 0)


### PR DESCRIPTION
## Summary
- add integration tests for core registration, email activation and OTP login
- cover basic CRUD flows for `RevenueJob` and `AccountsReceivable`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840410b8e90832db829db5e66231759