### PR TITLE
Add ITD loan balance and enable all app routes

### DIFF
--- a/cashcrm_project/urls.py
+++ b/cashcrm_project/urls.py
@@ -32,21 +32,21 @@ urlpatterns = [
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
     # API endpoints ของแต่ละแอป
-    path('api/core/', include('core.urls', namespace='core-api')),           # เช่น /api/core/users/
-    path('api/revenue/', include('revenue.urls', namespace='revenue-api')),  # เช่น /api/revenue/jobs/
-    # path('api/loans/', include('loans.urls', namespace='loans-api')),
-    # path('api/payables/', include('payables.urls', namespace='payables-api')),
-    # path('api/cashflow/', include('cashflow.urls', namespace='cashflow-api')),
-    # path('api/fleet/', include('fleet.urls', namespace='fleet-api')),
-    # path('api/mineprogress/', include('mineprogress.urls', namespace='mineprogress-api')),
+    path('api/core/', include('core.urls', namespace='core-api')),
+    path('api/revenue/', include('revenue.urls', namespace='revenue-api')),
+    path('api/loans/', include('loans.urls', namespace='loans-api')),
+    path('api/payables/', include('payables.urls', namespace='payables-api')),
+    path('api/cashflow/', include('cashflow.urls', namespace='cashflow-api')),
+    path('api/fleet/', include('fleet.urls', namespace='fleet-api')),
+    path('api/mineprogress/', include('mineprogress.urls', namespace='mineprogress-api')),
     
     # Frontend URLs ของแต่ละแอป (Web)
     path('revenue/', include('revenue.urls', namespace='revenue')),
-    # path('loans/', include('loans.urls', namespace='loans')),
-    # path('payables/', include('payables.urls', namespace='payables')),
-    # path('cashflow/', include('cashflow.urls', namespace='cashflow')),
-    # path('fleet/', include('fleet.urls', namespace='fleet')),
-    # path('mineprogress/', include('mineprogress.urls', namespace='mineprogress')),
+    path('loans/', include('loans.urls', namespace='loans')),
+    path('payables/', include('payables.urls', namespace='payables')),
+    path('cashflow/', include('cashflow.urls', namespace='cashflow')),
+    path('fleet/', include('fleet.urls', namespace='fleet')),
+    path('mineprogress/', include('mineprogress.urls', namespace='mineprogress')),
 ]
 
 # เสิร์ฟ media ไฟล์เฉพาะตอน DEBUG

--- a/cashflow/models.py
+++ b/cashflow/models.py
@@ -78,6 +78,10 @@ class ITDLoan(models.Model):
     created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='itdloan_created')
     created_on = models.DateField(default=timezone.now)
 
+    def remaining_balance(self):
+        """Return remaining credit available on this ITDLoan."""
+        return self.total_amount - self.used_amount
+
     def __str__(self):
         return f"{self.loan_name} (Total {self.total_amount} / Used {self.used_amount})"
 

--- a/cashflow/serializers.py
+++ b/cashflow/serializers.py
@@ -91,10 +91,24 @@ class PNLoanUsageSerializer(serializers.ModelSerializer):
 # —— ITDLoan ——
 #
 class ITDLoanSerializer(serializers.ModelSerializer):
+    remaining_balance = serializers.SerializerMethodField()
+
     class Meta:
         model = ITDLoan
-        fields = ['id', 'loan_name', 'total_amount', 'received_amount', 'used_amount', 'created_by', 'created_on']
-        read_only_fields = ['created_by', 'created_on']
+        fields = [
+            'id',
+            'loan_name',
+            'total_amount',
+            'received_amount',
+            'used_amount',
+            'remaining_balance',
+            'created_by',
+            'created_on'
+        ]
+        read_only_fields = ['created_by', 'created_on', 'remaining_balance']
+
+    def get_remaining_balance(self, obj):
+        return obj.remaining_balance()
 
     def create(self, validated_data):
         # บันทึกผู้ใช้งานปัจจุบันเป็น created_by

--- a/cashflow/tests.py
+++ b/cashflow/tests.py
@@ -1,3 +1,61 @@
-from django.test import TestCase
+from django.test import TestCase, Client, override_settings
+from django.contrib.auth.models import User, Group
+from decimal import Decimal
 
-# Create your tests here.
+from cashflow.models import BankAccount, ITDLoan, CashTransaction
+
+
+@override_settings(
+    SECRET_KEY="testsecret",
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DATABASES={
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    },
+)
+class ITDLoanWorkflowTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        group = Group.objects.create(name="cashflow_access")
+        self.user = User.objects.create_user("cashuser", password="pass123", is_active=True)
+        self.user.groups.add(group)
+        self.client.login(username="cashuser", password="pass123")
+
+    def test_itdloan_use_funds_and_balance(self):
+        bank = BankAccount.objects.create(
+            name="Main",
+            bank_name="TestBank",
+            account_number="123456",
+            balance=Decimal("0.00"),
+        )
+
+        resp = self.client.post(
+            "/api/cashflow/itdloan/",
+            {"loan_name": "ITD CEM Loan", "total_amount": "1000.00"},
+        )
+        self.assertEqual(resp.status_code, 201)
+        loan_id = resp.json()["id"]
+
+        detail = self.client.get(f"/api/cashflow/itdloan/{loan_id}/")
+        self.assertEqual(detail.status_code, 200)
+        self.assertEqual(detail.json()["remaining_balance"], "1000.00")
+
+        use_url = f"/api/cashflow/itdloan/{loan_id}/use_funds/"
+        resp = self.client.post(
+            use_url,
+            {"amount": "200.00", "description": "Test", "bank_account": bank.id},
+        )
+        self.assertEqual(resp.status_code, 201)
+
+        loan = ITDLoan.objects.get(id=loan_id)
+        self.assertEqual(loan.used_amount, Decimal("200.00"))
+
+        detail = self.client.get(f"/api/cashflow/itdloan/{loan_id}/")
+        self.assertEqual(detail.json()["remaining_balance"], "800.00")
+
+        self.assertEqual(CashTransaction.objects.count(), 1)
+        tx = CashTransaction.objects.first()
+        self.assertEqual(tx.transaction_type, "ITDLoan_Usage")
+        self.assertEqual(tx.amount, Decimal("200.00"))


### PR DESCRIPTION
## Summary
- expose API and web URLs for every app
- show remaining ITD loan balance
- test ITDLoan balance and use-funds workflow

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684050d19144832d827d3c9d0de4c9e5