### PR TITLE
Add placeholder HTML templates

### DIFF
--- a/cashflow/templates/cashflow/cashflowforecast_form.html
+++ b/cashflow/templates/cashflow/cashflowforecast_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Cash Flow Forecast Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Cash Flow Forecast Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/cashflowforecast_list.html
+++ b/cashflow/templates/cashflow/cashflowforecast_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Cash Flow Forecasts{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Cash Flow Forecasts</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/cashpayment_form.html
+++ b/cashflow/templates/cashflow/cashpayment_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Cash Payment Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Cash Payment Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/cashpayment_list.html
+++ b/cashflow/templates/cashflow/cashpayment_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Cash Payments{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Cash Payments</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/committeemember_form.html
+++ b/cashflow/templates/cashflow/committeemember_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Committee Member Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Committee Member Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/committeemember_list.html
+++ b/cashflow/templates/cashflow/committeemember_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Committee Members{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Committee Members</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/lcrequest_form.html
+++ b/cashflow/templates/cashflow/lcrequest_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}LC Request Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>LC Request Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/lcrequest_list.html
+++ b/cashflow/templates/cashflow/lcrequest_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}LC Requests{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>LC Requests</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/paymentrequest_form.html
+++ b/cashflow/templates/cashflow/paymentrequest_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Payment Request Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Payment Request Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/paymentrequest_list.html
+++ b/cashflow/templates/cashflow/paymentrequest_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Payment Requests{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Payment Requests</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/paymentrequestitem_form.html
+++ b/cashflow/templates/cashflow/paymentrequestitem_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Payment Request Item Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Payment Request Item Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/paymentrequestitem_list.html
+++ b/cashflow/templates/cashflow/paymentrequestitem_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Payment Request Items{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Payment Request Items</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/pnloanusage_form.html
+++ b/cashflow/templates/cashflow/pnloanusage_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}PN Loan Usage Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>PN Loan Usage Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/pnloanusage_list.html
+++ b/cashflow/templates/cashflow/pnloanusage_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}PN Loan Usages{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>PN Loan Usages</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/pnticket_form.html
+++ b/cashflow/templates/cashflow/pnticket_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}PN Ticket Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>PN Ticket Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/pnticket_list.html
+++ b/cashflow/templates/cashflow/pnticket_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}PN Tickets{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>PN Tickets</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/postfinancefacility_form.html
+++ b/cashflow/templates/cashflow/postfinancefacility_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}PostFinance Facility Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>PostFinance Facility Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/postfinancefacility_list.html
+++ b/cashflow/templates/cashflow/postfinancefacility_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}PostFinance Facilities{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>PostFinance Facilities</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/projectcashaccount_form.html
+++ b/cashflow/templates/cashflow/projectcashaccount_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Project Cash Account Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Project Cash Account Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/projectcashaccount_list.html
+++ b/cashflow/templates/cashflow/projectcashaccount_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Project Cash Accounts{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Project Cash Accounts</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/trrequest_form.html
+++ b/cashflow/templates/cashflow/trrequest_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}TR Request Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>TR Request Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/trrequest_list.html
+++ b/cashflow/templates/cashflow/trrequest_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}TR Requests{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>TR Requests</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/vote_form.html
+++ b/cashflow/templates/cashflow/vote_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Vote Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Vote Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/cashflow/templates/cashflow/vote_list.html
+++ b/cashflow/templates/cashflow/vote_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Votes{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Votes</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/fleet/templates/fleet/gpslog_detail.html
+++ b/fleet/templates/fleet/gpslog_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}GPS Log Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>GPS Log Detail</h2>
+  <!-- TODO: display GPS log information -->
+</div>
+{% endblock %}

--- a/fleet/templates/fleet/gpslog_form.html
+++ b/fleet/templates/fleet/gpslog_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}GPS Log Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>GPS Log Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/fleet/templates/fleet/gpslog_list.html
+++ b/fleet/templates/fleet/gpslog_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}GPS Logs{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>GPS Logs</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/fleet/templates/fleet/truck_detail.html
+++ b/fleet/templates/fleet/truck_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Truck Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Truck Detail</h2>
+  <!-- TODO: display truck information -->
+</div>
+{% endblock %}

--- a/fleet/templates/fleet/truck_form.html
+++ b/fleet/templates/fleet/truck_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Truck Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Truck Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/fleet/templates/fleet/truck_list.html
+++ b/fleet/templates/fleet/truck_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Trucks{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Trucks</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/loans/templates/loans/bankloan_detail.html
+++ b/loans/templates/loans/bankloan_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Bank Loan Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Bank Loan Detail</h2>
+  <!-- TODO: display loan information -->
+</div>
+{% endblock %}

--- a/mineprogress/templates/mineprogress/documentcheck_detail.html
+++ b/mineprogress/templates/mineprogress/documentcheck_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Document Check Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Document Check Detail</h2>
+  <!-- TODO: display document check information -->
+</div>
+{% endblock %}

--- a/mineprogress/templates/mineprogress/documentcheck_form.html
+++ b/mineprogress/templates/mineprogress/documentcheck_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Document Check Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Document Check Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/mineprogress/templates/mineprogress/documentcheck_list.html
+++ b/mineprogress/templates/mineprogress/documentcheck_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Document Checks{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Document Checks</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/mineprogress/templates/mineprogress/mineprogressreport_detail.html
+++ b/mineprogress/templates/mineprogress/mineprogressreport_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Mine Progress Report Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Mine Progress Report Detail</h2>
+  <!-- TODO: display report information -->
+</div>
+{% endblock %}

--- a/mineprogress/templates/mineprogress/mineprogressreport_form.html
+++ b/mineprogress/templates/mineprogress/mineprogressreport_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Mine Progress Report Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Mine Progress Report Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/mineprogress/templates/mineprogress/mineprogressreport_list.html
+++ b/mineprogress/templates/mineprogress/mineprogressreport_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Mine Progress Reports{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Mine Progress Reports</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/notifications/templates/notifications/notification_detail.html
+++ b/notifications/templates/notifications/notification_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Notification Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Notification Detail</h2>
+  <!-- TODO: display notification information -->
+</div>
+{% endblock %}

--- a/notifications/templates/notifications/notification_list.html
+++ b/notifications/templates/notifications/notification_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Notifications{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Notifications</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/accountspayable_detail.html
+++ b/payables/templates/payables/accountspayable_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Accounts Payable Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Accounts Payable Detail</h2>
+  <!-- TODO: display AP information -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/accountspayable_form.html
+++ b/payables/templates/payables/accountspayable_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Accounts Payable Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Accounts Payable Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/payables/templates/payables/accountspayable_list.html
+++ b/payables/templates/payables/accountspayable_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Accounts Payable{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Accounts Payable</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/siteoperationexpense_detail.html
+++ b/payables/templates/payables/siteoperationexpense_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Site Operation Expense Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Site Operation Expense Detail</h2>
+  <!-- TODO: display expense information -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/siteoperationexpense_form.html
+++ b/payables/templates/payables/siteoperationexpense_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Site Operation Expense Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Site Operation Expense Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/payables/templates/payables/siteoperationexpense_list.html
+++ b/payables/templates/payables/siteoperationexpense_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Site Operation Expenses{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Site Operation Expenses</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/suppliercredit_detail.html
+++ b/payables/templates/payables/suppliercredit_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Supplier Credit Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Supplier Credit Detail</h2>
+  <!-- TODO: display credit information -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/suppliercredit_form.html
+++ b/payables/templates/payables/suppliercredit_form.html
@@ -1,0 +1,12 @@
+{% extends 'core/base.html' %}
+{% block title %}Supplier Credit Form{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Supplier Credit Form</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+{% endblock %}

--- a/payables/templates/payables/suppliercredit_list.html
+++ b/payables/templates/payables/suppliercredit_list.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Supplier Credits{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Supplier Credits</h2>
+  <!-- TODO: implement listing -->
+</div>
+{% endblock %}

--- a/payables/templates/payables/vendor_detail.html
+++ b/payables/templates/payables/vendor_detail.html
@@ -1,0 +1,8 @@
+{% extends 'core/base.html' %}
+{% block title %}Vendor Detail{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2>Vendor Detail</h2>
+  <!-- TODO: display vendor information -->
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add basic HTML templates across all apps
- create placeholders for fleet, mineprogress, notifications, payables, cashflow
- include new detail view templates for bank loans

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68405b922c78832dbdac4f00f36a8823