### PR TITLE
Fix MineProgress group name

### DIFF
--- a/mineprogress/permissions.py
+++ b/mineprogress/permissions.py
@@ -2,7 +2,7 @@ from rest_framework import permissions
 
 class IsMineProgressUser(permissions.BasePermission):
     """
-    ตรวจสอบว่า user อยู่ในกลุ่ม 'mineprogress_user' หรือไม่
+    ตรวจสอบว่า user อยู่ในกลุ่ม 'mineprogress_access' หรือไม่
     """
     def has_permission(self, request, view):
-        return request.user.groups.filter(name='mineprogress_user').exists()
+        return request.user.groups.filter(name='mineprogress_access').exists()


### PR DESCRIPTION
## Summary
- update MineProgress permission class to check for `mineprogress_access`

## Testing
- `python -m pytest`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68407f199264832d86d06c83855f9b72