### PR TITLE
Improve LINE notification error handling

### DIFF
--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -4,6 +4,9 @@ from django.core.mail import send_mail
 from django.conf import settings
 from .models import Notification
 import requests
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task
@@ -42,8 +45,8 @@ def send_notification(user_id: int, title: str, message: str, channel: str):
                     headers=headers,
                     timeout=10,
                 )
-            except Exception:
-                pass
+            except requests.RequestException:
+                logger.exception("LINE notification failed")
 
     Notification.objects.create(
         user=user,


### PR DESCRIPTION
## Summary
- log LINE notification failures
- catch RequestException instead of bare Exception

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68407f154264832db6eabf86170c9620