### PR TITLE
Add minimal tests and test DB config

### DIFF
--- a/cashcrm_project/settings.py
+++ b/cashcrm_project/settings.py
@@ -26,7 +26,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY')
+SECRET_KEY = os.getenv('SECRET_KEY', 'insecure-secret-key')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG', '0') == '1'
@@ -132,16 +132,24 @@ CHANNEL_LAYERS = {
 #     }
 # }
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('DB_NAME'),
-        'USER': os.getenv('DB_USER'),
-        'PASSWORD': os.getenv('DB_PASSWORD'),
-        'HOST': os.getenv('DB_HOST'),  # หรือเป็น IP หรือชื่อโฮสต์ของฐานข้อมูล
-        'PORT': os.getenv('DB_PORT'),  # Default PostgreSQL port
+if os.getenv('RUNNING_TESTS') == 'True':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'test.db',
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.getenv('DB_NAME'),
+            'USER': os.getenv('DB_USER'),
+            'PASSWORD': os.getenv('DB_PASSWORD'),
+            'HOST': os.getenv('DB_HOST'),  # หรือเป็น IP หรือชื่อโฮสต์ของฐานข้อมูล
+            'PORT': os.getenv('DB_PORT'),  # Default PostgreSQL port
+        }
+    }
 
 
 # Password validation

--- a/fleet/tests.py
+++ b/fleet/tests.py
@@ -1,3 +1,9 @@
 from django.test import TestCase
+from .models import Truck
 
-# Create your tests here.
+
+class TruckModelTest(TestCase):
+    def test_string_representation(self):
+        truck = Truck.objects.create(number_plate="AB-123", driver_name="Bob")
+        self.assertEqual(str(truck), "AB-123")
+

--- a/mineprogress/tests.py
+++ b/mineprogress/tests.py
@@ -1,3 +1,20 @@
+from datetime import date
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from .models import MineProgressReport
 
-# Create your tests here.
+User = get_user_model()
+
+
+class MineProgressReportModelTest(TestCase):
+    def test_string_representation(self):
+        user = User.objects.create(username="reporter")
+        report = MineProgressReport.objects.create(
+            report_date=date.today(),
+            description="Test", 
+            progress_pct=1.5,
+            created_by=user,
+        )
+        expected = f"Report {report.id} on {report.report_date} ({report.progress_pct}%)"
+        self.assertEqual(str(report), expected)
+

--- a/payables/tests.py
+++ b/payables/tests.py
@@ -1,3 +1,20 @@
+from decimal import Decimal
+from datetime import date
 from django.test import TestCase
+from .models import Vendor, AccountsPayable
 
-# Create your tests here.
+
+class AccountsPayableModelTest(TestCase):
+    def test_outstanding_amount_computed_correctly(self):
+        vendor = Vendor.objects.create(name="Test Vendor")
+        ap = AccountsPayable.objects.create(
+            vendor=vendor,
+            invoice_number="INV-1",
+            invoice_date=date.today(),
+            due_date=date.today(),
+            amount=Decimal("100.00"),
+            year=2566,
+            paid_amount=Decimal("40.00"),
+        )
+        self.assertEqual(ap.outstanding_amount, Decimal("60.00"))
+


### PR DESCRIPTION
## Summary
- add simple model tests for payables, fleet and mineprogress apps
- switch settings to an SQLite database when `RUNNING_TESTS` is set
- provide default secret key so tests can run without env vars

## Testing
- `RUNNING_TESTS=True python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohappyeyeballs==2.4.4)*

------
https://chatgpt.com/codex/tasks/task_e_68407f0f4268832d93bcbb3e9c0b0d9b